### PR TITLE
Add support for PHP via FastCGI

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,5 +1,8 @@
 RewriteEngine On
 
+# Forward HTTP BASIC auth headers when using FastCGI
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]
+
 RewriteCond %{THE_REQUEST} !^GET\ .*?/client/([a-z]\.(js|css)|img/|libs/)
 RewriteCond %{THE_REQUEST} !^GET\ .*?/server/theme/
 RewriteCond %{REQUEST_FILENAME} !-f

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,7 +1,7 @@
 RewriteEngine On
 
 # Forward HTTP BASIC auth headers when using FastCGI
-RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
 RewriteCond %{THE_REQUEST} !^GET\ .*?/client/([a-z]\.(js|css)|img/|libs/)
 RewriteCond %{THE_REQUEST} !^GET\ .*?/server/theme/


### PR DESCRIPTION
I found out the hard way that HTTP BASIC auth works differently on servers with FastCGI. The headers weren't passed on.

This solved the problem by forwarding the auth data and exploding it from `REDIRECT_HTTP_AUTHORIZATION`

- htaccess change description https://www.versatilewebsolutions.com/blog/2013/05/basic-authentication-with-fastcgi.html
- Similar issue (when PHP is not loaded as a module) https://github.com/yiisoft/yii2/issues/13564
    - We could look into treating both redirect/non-redirect variants the same to simplify the code: https://github.com/yiisoft/yii2/commit/0b2e79eac590cf01f0985fb696da8f3c54271361#diff-389a9016415fb7f682c722606d1eb437f71dddb5da38660fc96669c7338f7833R131
- Fix (German) https://wiki.hostsharing.net/index.php?title=SeedDMS_installieren#Fast-CGI-Patch 
- Similar solution in English: http://www.rosmir.org/Index/Docs/archive/LabsFolder/FastCGI

In my testing, this patch works on PHP via FastCGI servers and doesn't break local testing when running `php -S`. 