### PR TITLE
Add private mode: require login for reading

### DIFF
--- a/src/config-example.php
+++ b/src/config-example.php
@@ -19,3 +19,6 @@ $config['lang'] = 'en'; // 'de' or 'en'
 //$config['showToc'] = false;
 
 //$config['footerHtml'] = '&copy; Copyright 2000-'.date('Y').' My name';
+
+// Make all content read-only for guests, requiring login to read and edit.
+//$config['private'] = true;

--- a/src/server/i18n/de.php
+++ b/src/server/i18n/de.php
@@ -21,5 +21,6 @@ $i18n = array(
     'createUser.userName' => 'Benutzername',
     'createUser.password' => 'Passwort',
     'createUser.showConfig' => 'Konfiguration anzeigen',
-    'createUser.addToConfig' => 'Fügen Sie die folgende Zeile zu Ihrer <code>config.php</code> hinzu:'
+    'createUser.addToConfig' => 'Fügen Sie die folgende Zeile zu Ihrer <code>config.php</code> hinzu:',
+    'private.placeholder' => "# Privates Wiki\n\nAnmelden, um Inhalte anzuzeigen.",
 );

--- a/src/server/i18n/en.php
+++ b/src/server/i18n/en.php
@@ -21,5 +21,6 @@ $i18n = array(
     'createUser.userName' => 'User name',
     'createUser.password' => 'Password',
     'createUser.showConfig' => 'Show config',
-    'createUser.addToConfig' => 'Add the following line to your <code>config.php</code>:'
+    'createUser.addToConfig' => 'Add the following line to your <code>config.php</code>:',
+    'private.placeholder' => "# Private Wiki\n\nSign up to access any content.",
 );

--- a/src/server/layout/page.php
+++ b/src/server/layout/page.php
@@ -110,7 +110,7 @@ if ($mode == 'edit') {
     <?php
   }
 
-  if ($mode == 'view' || $mode == 'edit' || $mode == 'noSuchArticle' || $mode == 'createArticle') {
+  if ($mode == 'view' || $mode == 'edit' || $mode == 'noSuchArticle' || $mode == 'private' || $mode == 'createArticle') {
     include($themeDir . '/page-header.php');
   }
 
@@ -121,7 +121,7 @@ if ($mode == 'edit') {
       </div></div><?php
   }
 
-  if ($mode == 'view' || $mode == 'edit') {
+  if ($mode == 'view' || $mode == 'edit' || $mode == 'private') {
     include($themeDir . '/content.php');
   }
 

--- a/src/server/logic/Context.php
+++ b/src/server/logic/Context.php
@@ -102,6 +102,17 @@ class Context {
         return 'wrong-credentials';
     }
 
+    /**
+     * Determines if the user has permission to see the requested page.
+     */
+    public function canAccessPage() {
+        if ($this->getConfig()['private']) {
+            return $this->getLoginState() == 'logged-in';
+        } else {
+            return true;
+        }
+    }
+
     public function assertLoggedIn() {
         if ($this->getLoginState() != 'logged-in') {
             throw new Exception('Not logged in');

--- a/src/server/logic/Context.php
+++ b/src/server/logic/Context.php
@@ -69,6 +69,44 @@ class Context {
         return ! is_string($articleFilename) || ! strpos($articleFilename, '..');
     }
 
+    // Returns tuple of username/password or [null,null].
+    private function getUserCredentials() {
+        if (isset($_SERVER["REDIRECT_HTTP_AUTHORIZATION"]) && !empty($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+            list ($auth_type, $cred) = explode (" ", $_SERVER['REDIRECT_HTTP_AUTHORIZATION']);
+            if ($auth_type == 'Basic') {
+                return explode (":", base64_decode($cred));
+            }
+        } else if (isset($_SERVER['PHP_AUTH_USER'])) {
+            return array( $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] );
+        }
+        return array(null, null);
+    }
+
+    // Returns one of: 'logged-in', 'no-credentials', 'wrong-credentials'
+    public function getLoginState() {
+        list ($auth_user,  $auth_pw) = $this->getUserCredentials();
+
+        if (!($auth_user && $auth_pw)) {
+            return 'no-credentials';
+        }
+
+        $userInfo = $this->context->getConfig()['user.' . $auth_user];
+        if (isset($userInfo)) {
+            $loginHash = hash($userInfo['type'], $auth_pw . $userInfo['salt']);
+            if ($loginHash == $userInfo['hash']) {
+                return 'logged-in';
+            }
+        }
+
+        return 'wrong-credentials';
+    }
+
+    public function assertLoggedIn() {
+        if ($this->getLoginState() != 'logged-in') {
+            throw new Exception('Not logged in');
+        }
+    }
+
     public function getEditorService() {
         if (is_null($this->editorService)) {
             require_once __DIR__ . '/EditorService.php';

--- a/src/server/logic/Context.php
+++ b/src/server/logic/Context.php
@@ -91,7 +91,7 @@ class Context {
             return 'no-credentials';
         }
 
-        $userInfo = $this->context->getConfig()['user.' . $auth_user];
+        $userInfo = $this->getConfig()['user.' . $auth_user];
         if (isset($userInfo)) {
             $loginHash = hash($userInfo['type'], $auth_pw . $userInfo['salt']);
             if ($loginHash == $userInfo['hash']) {

--- a/src/server/logic/Context.php
+++ b/src/server/logic/Context.php
@@ -33,7 +33,8 @@ class Context {
             'demoMode' => false,
             'openExternalLinksInNewTab' => true,
             'showCompleteBreadcrumbs' => true,
-            'showToc'  => true
+            'showToc'  => true,
+            'private'  => false,
         );
 
         if (file_exists(__DIR__ . '/../../config.php')) {

--- a/src/server/logic/Main.php
+++ b/src/server/logic/Main.php
@@ -79,7 +79,7 @@ class Main {
         }
 
         if ($mode == 'edit' && ! $config['demoMode']) {
-            $loginState = $this->context->getEditorService()->getLoginState();
+            $loginState = $this->context->getLoginState();
             if ($loginState != 'logged-in') {
                 $this->setUnauthorizedHeaders();
 

--- a/src/server/logic/Main.php
+++ b/src/server/logic/Main.php
@@ -123,8 +123,8 @@ class Main {
         }
 
         $data = array();
-        $data['baseUrl']    = $baseUrl;
-        $data['basePath']   = $basePath;
+        $data['baseUrl'] = $baseUrl;
+        $data['basePath'] = $basePath;
         $data['mode'] = $mode;
         $data['fatalErrorMessage'] = $fatalErrorMessage;
 

--- a/src/server/logic/Main.php
+++ b/src/server/logic/Main.php
@@ -79,7 +79,7 @@ class Main {
         }
 
         // In private mode, prompt for login in both edit and view modes.
-        if (! $config['demoMode'] && ($mode == 'edit' || $config['private'])) {
+        if (! $config['demoMode'] && $mode == 'edit') {
             $loginState = $this->context->getLoginState();
             if ($loginState != 'logged-in') {
                 $this->setUnauthorizedHeaders();
@@ -89,7 +89,8 @@ class Main {
             }
         }
 
-        if (! $this->context->canAccessPage()) {
+        // Limit what users can see and request login in private mode, unless we're in account creation.
+        if (! $this->context->canAccessPage() && $mode !== 'createUser') {
             $this->setUnauthorizedHeaders();
 
             $mode = 'private';
@@ -103,6 +104,7 @@ class Main {
             echo '<h1>Forbidden</h1>';
             return;
         }
+
         $renderService = $this->context->getRenderService();
 
         $fatalErrorMessage = null;

--- a/src/server/logic/Main.php
+++ b/src/server/logic/Main.php
@@ -141,9 +141,7 @@ class Main {
         $data['articleFilename'] = $articleFilename;
 
         if ($mode == 'private') {
-            $articleMarkdown = "# Private Wiki\n\nSign up to access any content.";
-            $data['articleMarkdown'] = $articleMarkdown;
-            $data['articleHtml'] = $renderService->renderMarkdown($articleMarkdown, false);
+            $articleMarkdown = $this->context->getI18n()['private.placeholder'];
         } else if ($mode == 'view' || $mode == 'edit') {
             if ($renderService->articleExists($articleFilename)) {
                 $articleMarkdown = file_get_contents($this->context->getArticleBaseDir() . $articleFilename);
@@ -161,9 +159,10 @@ class Main {
                 $editorService = $this->context->getEditorService();
                 $articleMarkdown = $editorService->getNewArticleMarkdown($pageTitle);
             }
-            $data['articleMarkdown'] = $articleMarkdown;
-            $data['articleHtml'] = $renderService->renderMarkdown($articleMarkdown, $mode == 'edit');
         }
+
+        $data['articleMarkdown'] = $articleMarkdown;
+        $data['articleHtml'] = $renderService->renderMarkdown($articleMarkdown, $mode == 'edit');
 
         $this->renderPage($data);
     }

--- a/src/server/logic/Main.php
+++ b/src/server/logic/Main.php
@@ -78,7 +78,9 @@ class Main {
             $showCreateUserButton = ! $this->isUserDefined();
         }
 
-        if ($mode == 'edit' && ! $config['demoMode']) {
+        // In private mode, prompt for login in both edit and view modes.
+        if (! $config['demoMode']
+            && ($mode == 'edit' || $config['private'])) {
             $loginState = $this->context->getLoginState();
             if ($loginState != 'logged-in') {
                 $this->setUnauthorizedHeaders();

--- a/src/server/logic/Main.php
+++ b/src/server/logic/Main.php
@@ -142,6 +142,8 @@ class Main {
         $data['requestPath'] = implode('/', $requestPathArray);
         $data['articleFilename'] = $articleFilename;
 
+        $articleMarkdown = '';
+
         if ($mode == 'private') {
             $articleMarkdown = $this->context->getI18n()['private.placeholder'];
         } else if ($mode == 'view' || $mode == 'edit') {


### PR DESCRIPTION
For an internal wiki, we wanted to not render any page contents unless the visitor is logged-in.

So I extracted the state management logic, refactored things a bit, and introduced a new `$mode = 'private';` that renders a static placeholder text.

# Features

- login prompt on every page
- _no_ login prompt for `?createUser` pages

## English/German i18n
![Screen Shot 2022-05-02 at 10 23 55](https://user-images.githubusercontent.com/59080/166214302-354ed4b5-b618-4754-b27a-c9effade8445.png)
![Screen Shot 2022-05-02 at 10 24 01](https://user-images.githubusercontent.com/59080/166214305-2b17fb02-5262-48f3-a9c7-ce01ebdcc136.png)

## Does not expose if the URL exists

With the standard set of files from this repo, `/notfound` shows the same placeholder. So no spying on paths!

![Screen Shot 2022-05-02 at 11 27 05](https://user-images.githubusercontent.com/59080/166214344-d17211d4-3c63-4358-92dc-a8cc58cfe072.png)

